### PR TITLE
Add UPC field to beverages

### DIFF
--- a/app/controllers/beverages_controller.rb
+++ b/app/controllers/beverages_controller.rb
@@ -69,6 +69,6 @@ class BeveragesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def beverage_params
-      params.require(:beverage).permit(:name)
+      params.require(:beverage).permit(:name, :upc)
     end
 end

--- a/app/models/beverage.rb
+++ b/app/models/beverage.rb
@@ -2,12 +2,5 @@ class Beverage < ActiveRecord::Base
   has_many :ratings
   has_many :users, through: :ratings
 
-  validate :upc_length
   validates_presence_of :upc
-
-  def upc_length
-    unless upc.size == 8 or upc.size == 12
-      errors.add(:upc, "length must be 8 or 12")
-    end
-  end
 end

--- a/app/models/beverage.rb
+++ b/app/models/beverage.rb
@@ -1,4 +1,13 @@
 class Beverage < ActiveRecord::Base
   has_many :ratings
   has_many :users, through: :ratings
+
+  validate :upc_length
+  validates_presence_of :upc
+
+  def upc_length
+    unless upc.size == 8 or upc.size == 12
+      errors.add(:upc, "length must be 8 or 12")
+    end
+  end
 end

--- a/db/migrate/20160215034146_add_upc_to_beverage.rb
+++ b/db/migrate/20160215034146_add_upc_to_beverage.rb
@@ -1,0 +1,5 @@
+class AddUpcToBeverage < ActiveRecord::Migration
+  def change
+    add_column :beverages, :upc, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160211030638) do
+ActiveRecord::Schema.define(version: 20160215034146) do
 
   create_table "beverages", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "upc"
   end
 
   create_table "ratings", force: :cascade do |t|

--- a/test/controllers/beverages_controller_test.rb
+++ b/test/controllers/beverages_controller_test.rb
@@ -18,7 +18,7 @@ class BeveragesControllerTest < ActionController::TestCase
 
   test "should create beverage" do
     assert_difference('Beverage.count') do
-      post :create, beverage: { name: @beverage.name }
+      post :create, beverage: { name: @beverage.name, upc: @beverage.upc }
     end
 
     assert_redirected_to beverage_path(assigns(:beverage))
@@ -35,7 +35,7 @@ class BeveragesControllerTest < ActionController::TestCase
   end
 
   test "should update beverage" do
-    patch :update, id: @beverage, beverage: { name: @beverage.name }
+    patch :update, id: @beverage, beverage: { name: @beverage.name, upc: @beverage.upc}
     assert_redirected_to beverage_path(assigns(:beverage))
   end
 

--- a/test/fixtures/beverages.yml
+++ b/test/fixtures/beverages.yml
@@ -2,6 +2,8 @@
 
 natty:
   name: Natural Light
+  upc: '12345678'
 
 moon:
   name: Blue Moon
+  upc: '123456789012'

--- a/test/models/beverage_test.rb
+++ b/test/models/beverage_test.rb
@@ -4,16 +4,4 @@ class BeverageTest < ActiveSupport::TestCase
   test 'validates presence' do
     validate_presence_of :upc
   end
-
-  context 'with a 8 character upc' do
-    should allow_value('12345678').for(:upc)
-  end
-
-  context 'with a 12 character upc' do
-    should allow_value('123456789012').for(:upc)
-  end
-
-  context 'with an invalid upc character count' do
-    should_not allow_value('12345678901').for(:upc)
-  end
 end

--- a/test/models/beverage_test.rb
+++ b/test/models/beverage_test.rb
@@ -1,7 +1,19 @@
 require 'test_helper'
 
 class BeverageTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'validates presence' do
+    validate_presence_of :upc
+  end
+
+  context 'with a 8 character upc' do
+    should allow_value('12345678').for(:upc)
+  end
+
+  context 'with a 12 character upc' do
+    should allow_value('123456789012').for(:upc)
+  end
+
+  context 'with an invalid upc character count' do
+    should_not allow_value('12345678901').for(:upc)
+  end
 end


### PR DESCRIPTION
I've added the UPC field along with a custom upc_length validation which
ensures the UPC code is one of the standard lengths (8 or 12
characters).
